### PR TITLE
changed logger debug to warning for invalid Github/Gitlab URL

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,7 +75,7 @@ def check_url_candidates(url_candidates: List, name: str) -> Dict[str, Any]:
             if response.status_code == 200:
                 possible_urls.append(source_url)
             else:
-                _LOGGER.debug("%r is an invalid Github/GitLab URL", source_url)
+                _LOGGER.warning("%r is an invalid Github/GitLab URL", source_url)
         except Exception:
             _LOGGER.exception("Failed to obtain %r with requests.head()", source_url)
 


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Changed invalid Github/Gitlab URL to a warning instead of a debug log, since if the URL doesn't work we want it to log it as a warning. This way we don't need debug mode to see URLs that are github.com/gitlab.com but are not sending status 200 response back. 
